### PR TITLE
Anpassungen für 8.3 das nicht nur ein Unterpunkt entsteht

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@
 *.tdo
 main.lot
 .idea
+*.gz(busy)

--- a/kapitel/gruppe4_2/sections/section3.tex
+++ b/kapitel/gruppe4_2/sections/section3.tex
@@ -10,8 +10,8 @@ Die folgenden Projekte wurden im Zeitraum 2005 - 2010 durchgeführt und haben ih
 
 Als Bestätigung dieser Zahlen weist die TU München mehr als fünfzig Mitarbeiterinnen und Mitarbeiter im Projekt aus. Zu ihrem integrierten Informationsmanagement bekam das Projekt insgesamt ca. 2,5 Mio. EUR. Die TU München stellte dazu selbst weitere Sondermittel aus dem Erneuerungsprojekt InnovaTUM zur Verfügung.\footnote{\cite{bode_informationsmanagement_2010}}
 
-\subsection{Beispiele des integrierten Informationsmanagements}
-Münster Information System for Research and Organization (MIRO) ist das integrierte Informationsmanagement an der Westfälischen Wilhelms-Universität  (WWU) Münster.
+Im diesem Abschnitt werden die Referenz-Beispiele des integrierten Informationsmanagements mit DFG Förderung betrachtet, da hierfür einige Zahlen bekannt sind, mit denen eine
+Überlegung für die Hochschule Emden/Leer angestellt werden kann. Das erste Referenz-Beispiel des integrierte Informationsmanagements ist das Münster Information System for Research and Organization (MIRO) an der Westfälischen Wilhelms-Universität (WWU) Münster.
 
 Die ersten Bemühungen starteten im Jahr 2003 und wurden in den folgenden Jahren vorangetrieben. Im Jahre 2005 wie zum abschließenden Berichtsstand der WWU 2013 existierten 15 Fachbereiche an der WWU. Die 130 Studienfächer sanken in diesem Zeitraum auf 110. Auch die ca. 39.000 Studierenden sind im Jahr 2013 auf ca. 37.000 Studierende gesunken. An der WWU waren zum Zeitpunkt der Antragstellung etwa 5.000 Personen beschäftigt, davon 600 Professoren, 2.600 wissenschaftliche und 1.800 weitere Mitarbeiter. Im Jahr 2013 sind über 550 Professoren und ca. 3800 wissenschaftliche Beschäftigte an der WWU.\footnote{\cite{vogl_bericht_2013}}
 
@@ -25,6 +25,11 @@ Die ersten Bemühungen starteten im Jahr 2003 und wurden in den folgenden Jahren
 		\item Mobile Dienste (Alfresco)
 		\item Portalinfrastruktur (Apache Webserver, JBoss, Oracle Cluster)
 	\end{itemize}
+\end{itemize}
+
+\newpage
+		
+\begin{itemize}	
 	\item Aufwand
 	\begin{itemize}
 		\item 16 wissenschaftliche Mitarbeiter - 8 davon DFG gefördert
@@ -58,7 +63,14 @@ Die geschätzten Kosten der Projektmitarbeiter der Tabelle \ref{tab_minimale_inv
 
 Die Angabe der Personalkosten von 75 \%  leitet sich aus einem Bericht der Kosten in fertigenden Unternehmen und der Automobilbranche ab.\footnote{\cite{schuelein_2009}}
 
-Ein weiteres Projekt ist das „Karlsruher Integriertes InformationsManagement“ (KIM).
+Ein weiteres Projekt des integrierten Informationsmanagements ist das „Karlsruher Integriertes InformationsManagement“ (KIM).
+KIM ist im Ansatz eine dienstorientierte Föderation, in der die jeweiligen Fachbereiche sich an bestimmte Schnittstellen 
+halten und selbst die Dienste in ihrer bevorzugten Art und Programmierung zur Verfügung stellen. Dabei wurde ein hoch komplexes, 
+aber nach eigenen Angaben sehr flexibles System, im Rahmen der 5 Jahre DFG Förderung, geschaffen.\footnote{\cite{bode_informationsmanagement_2010}}
+Die Abbildung \ref{fig_ubersicht_karlsruhe} zeigt am besten, was in diesem Projekt erreicht wurde, da ein schriftliche Beschreibung den Rahmen dieser Arbeit überschreiten würde.
+
+\newpage
+
 \begin{figure}[h!]
 	\centering
 	\includegraphics[width=\textwidth]
@@ -67,7 +79,9 @@ Ein weiteres Projekt ist das „Karlsruher Integriertes InformationsManagement�
 	\label{fig_ubersicht_karlsruhe}
 \end{figure}
 
-KIM ist im Ansatz eine dienstorientierte Föderation, in der die jeweiligen Fachbereiche sich an bestimmte Schnittstellen halten und selbst die Dienste in ihrer bevorzugten Art und Programmierung zur Verfügung stellen. Dabei wurde ein hoch komplexes, aber nach eigenen Angaben sehr flexibles System, im Rahmen der 5 Jahre DFG Förderung, geschaffen.\footnote{\cite{bode_informationsmanagement_2010}}
+Besonders gut sind in der Abbildung \ref{fig_ubersicht_karlsruhe} die einzelen unabhängigen Systeme zu erkennen, die von den einzelnen Fachbereichen gepflegt und angeboten werden. 
+
+\newpage
 
 An der Universität Karlsruhe studieren (Stand 02/2014) ca. 24.500 Studenten ca. 9500 Mitarbeiter davon 346 Professoren mit Einnahmen in Mio. EUR 795 wovon Drittmittel EUR 339 Mio. betragen. Die Landesmittel sind mit EUR 212 Mio. und die Bundesmittel mit EUR 349 Mio. angegeben.\footnote{\url{https://www.kit.edu/mediathek/print_forschung/Flyer_KIT_de.pdf}} Den CIO bilden Rektorat und Vorstand.
 
@@ -80,6 +94,7 @@ An der Universität Karlsruhe studieren (Stand 02/2014) ca. 24.500 Studenten ca.
 \end{figure}
 
 Aus den bekannten Werten des Projektes MIRO kann nun abgeleitet werden, wieviele Personen an dem Projekt mitgewirkt haben könnten und welche Beträge für sonstige Kosten zur Verfügung standen. Diese Annahme in der Tabelle \ref{tab_minimale_investition_karlsruhe} ist rein fiktiv und dient lediglich dem Vergleich mit dem Projekt MIRO, dass den selben DFG-Förderungen gegenüber steht.
+
 
 \todo[inline]{Tabelle neu formatieren}
 \begin{table}[h!]


### PR DESCRIPTION
sind aktuell ein paar nepages reingekommen, die sich sicher im Verlauf verschieben können - bitte immer darauf achten, dass die Grafiken zum Textblock passen. Vielleicht kann man noch Grafiken als trennend und nicht umschließend definieren, dann sorgt eine Grafik immer für eine Textverschiebung und verschiebt sich nicht allein

http://golatex.de/abbildung-ist-automatisch-auf-neuer-seite-t2843.html